### PR TITLE
reduced the calls to pull and read in the data to only once

### DIFF
--- a/R/nhanes_translate.R
+++ b/R/nhanes_translate.R
@@ -42,16 +42,14 @@ nhanesTranslate <- function(nh_table, colnames=NULL, data = NULL, nchar = 32,
     warning("When a data table is passed to nhanesTranslate, the details variable is ignored")
   }
   
-  get_translation_table <- function(colname, url, details) {
+  get_translation_table <- function(colname, hurl, details) {
     xpt <- str_c('//*[h3[a[@name="', colname, '"]]]', sep='')
     
-    hurl <- .checkHtml(url)
     tabletree <- hurl %>% html_elements(xpath=xpt)
     #    tabletree <- url %>% read_html() %>% html_elements(xpath=xpt)
     if(length(tabletree)==0) { # If not found then try 'id' instead of 'name'
       xpt <- str_c('//*[h3[@id="', colname, '"]]', sep='')
       
-      hurl <- .checkHtml(url)
       tabletree <- hurl %>% html_elements(xpath=xpt)
       #      tabletree <- url %>% read_html() %>% html_elements(xpath=xpt)
     }
@@ -64,13 +62,11 @@ nhanesTranslate <- function(nh_table, colnames=NULL, data = NULL, nchar = 32,
         stringr::str_sub(lcnm, start=nc, end=nc) <- tolower(stringr::str_sub(lcnm, start=nc, end=nc))
         xpt <- str_c('//*[h3[a[@name="', lcnm, '"]]]', sep='')
         
-        hurl <- .checkHtml(url)
         tabletree <- hurl %>% html_elements(xpath=xpt)
-        #        tabletree <- url %>% read_html() %>% html_elements(xpath=xpt)
+
         if(length(tabletree)==0) { # If not found then try 'id' instead of 'name'
           xpt <- str_c('//*[h3[@id="', lcnm, '"]]', sep='')
           
-          hurl <- .checkHtml(url)
           tabletree <- hurl %>% html_elements(xpath=xpt)
           #          tabletree <- url %>% read_html() %>% html_elements(xpath=xpt)
         }
@@ -113,7 +109,8 @@ nhanesTranslate <- function(nh_table, colnames=NULL, data = NULL, nchar = 32,
       code_translation_url <- str_c(nhanesURL, nh_year, '/', nh_table, '.htm', sep='')
     }
   }
-  translations <- lapply(colnames, get_translation_table, code_translation_url, details)
+  hurl <- .checkHtml(code_translation_url)
+  translations <- lapply(colnames, get_translation_table, hurl, details)
   names(translations) <- colnames
   
   #nchar_max <- 128


### PR DESCRIPTION
In https://github.com/cjendres1/nhanes/blob/79af9d783f1ec66651881c0ab3ff9d06c38d5256/R/nhanes_internal_functions.R#L63, it uses `read_html`, which must download the file every time it is called.

This is called at:
https://github.com/cjendres1/nhanes/blob/master/R/nhanes_translate.R#L48

https://github.com/cjendres1/nhanes/blob/master/R/nhanes_translate.R#L54

https://github.com/cjendres1/nhanes/blob/master/R/nhanes_translate.R#L67

https://github.com/cjendres1/nhanes/blob/master/R/nhanes_translate.R#L73

That isn't the worst result, but the fact that this is in the `lapply`: 
https://github.com/cjendres1/nhanes/blob/master/R/nhanes_translate.R#L116
then .checkHTML can be called up to 4 times **per column**.

## Demonstration of Speedup
``` r
remove.packages("nhanesA")
#> Removing package from '/Library/Frameworks/R.framework/Versions/4.2/Resources/library'
#> (as 'lib' is unspecified)

remotes::install_github("cjendres1/nhanes")
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo cjendres1/nhanes@HEAD
#> 
#> ── R CMD build ─────────────────────────────────────────────────────────────────
#> * checking for file ‘/private/var/folders/1s/wrtqcpxn685_zk570bnx9_rr0000gr/T/RtmpyBr4T2/remotesd0fc1364036a/cjendres1-nhanes-79af9d7/DESCRIPTION’ ... OK
#> * preparing ‘nhanesA’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘nhanesA_0.7.4.tar.gz’
df <- nhanesA::nhanes("DEMO_G")
system.time({
  out = nhanesA::nhanesTranslate(nh_table = "DEMO_G", data = df,
                                 colnames = colnames(df))
})
#> Translated columns: RIDSTATR RIAGENDR RIDRETH1 RIDRETH3 RIDEXMON DMQMILIZ DMQADFC DMDBORN4 DMDCITZN DMDYRSUS DMDEDUC3 DMDEDUC2 DMDMARTL RIDEXPRG SIALANG SIAPROXY SIAINTRP FIALANG FIAPROXY FIAINTRP MIALANG MIAPROXY MIAINTRP AIALANGA INDHHIN2 INDFMIN2 DMDHRGND DMDHRBR4 DMDHREDU DMDHRMAR DMDHSEDU
#>    user  system elapsed 
#>   2.741   0.171 118.018
unloadNamespace("nhanesA")
remove.packages("nhanesA")
#> Removing package from '/Library/Frameworks/R.framework/Versions/4.2/Resources/library'
#> (as 'lib' is unspecified)
remotes::install_github("muschellij2/nhanesA@translate")
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo muschellij2/nhanesA@translate
#> 
#> ── R CMD build ─────────────────────────────────────────────────────────────────
#> * checking for file ‘/private/var/folders/1s/wrtqcpxn685_zk570bnx9_rr0000gr/T/RtmpyBr4T2/remotesd0fc469a4f61/muschellij2-nhanesA-07fd596/DESCRIPTION’ ... OK
#> * preparing ‘nhanesA’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘nhanesA_0.7.4.tar.gz’
#> Adding 'nhanesA_0.7.4.tgz' to the cache

system.time({
  out = nhanesA::nhanesTranslate(nh_table = "DEMO_G", data = df,
                                 colnames = colnames(df))
})
#> Translated columns: RIDSTATR RIAGENDR RIDRETH1 RIDRETH3 RIDEXMON DMQMILIZ DMQADFC DMDBORN4 DMDCITZN DMDYRSUS DMDEDUC3 DMDEDUC2 DMDMARTL RIDEXPRG SIALANG SIAPROXY SIAINTRP FIALANG FIAPROXY FIAINTRP MIALANG MIAPROXY MIAINTRP AIALANGA INDHHIN2 INDFMIN2 DMDHRGND DMDHRBR4 DMDHREDU DMDHRMAR DMDHSEDU
#>    user  system elapsed 
#>   0.583   0.011   1.669
```

<sup>Created on 2023-07-31 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


