### PR TITLE
exclude  P and Y tables

### DIFF
--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -32,7 +32,7 @@
 #' 
 nhanes <- function(nh_table, includelabels = FALSE, translated=TRUE, nchar=128) {
 
-  if(!is.na(.collection_date) & !is.na(.container_version)){
+  if(!grepl("^(P_|Y_)\\w+", nh_table) & !is.na(.collection_date) & !is.na(.container_version)){
     return(.nhanesDB (nh_table,translated))
   }
 

--- a/R/nhanes_codebook.R
+++ b/R/nhanes_codebook.R
@@ -28,7 +28,7 @@ nhanesCodebook <- function(nh_table, colname=NULL, dxa=FALSE) {
 ##  if(is.null(colname)) 
 ##    colname = nhanesAttr(nh_table)$names
 
-  if(dxa==FALSE & !is.na(.collection_date) & !is.na(.container_version)){
+  if(dxa==FALSE & !grepl("^(P_|Y_)\\w+", nh_table) & !is.na(.collection_date) & !is.na(.container_version)){
     return(.nhanesCodebookDB(nh_table, colname))
   }
   

--- a/R/nhanes_search.R
+++ b/R/nhanes_search.R
@@ -36,7 +36,7 @@
 #'  \donttest{urin = nhanesSearch("urin", exclude_terms="During", ystart=2009)}
 #'  \donttest{dim(urin)}
 #'  \donttest{urine = nhanesSearch(c("urine", "urinary"), ignore.case=TRUE, ystop=2006, namesonly=TRUE)}
-#'  \donttest{dim(urine)}
+#'  \donttest{length(urine)}
 #' @export
 #' 
 nhanesSearch <- function(search_terms=NULL, exclude_terms=NULL, data_group=NULL, ignore.case=FALSE, 

--- a/R/nhanes_tables.R
+++ b/R/nhanes_tables.R
@@ -170,7 +170,7 @@ nhanesTableVars <- function(data_group, nh_table, details = FALSE, nchar=128, na
     return(NULL)
   }
 
-  if(!is.na(.collection_date) & !is.na(.container_version)){
+  if(!grepl("^(P_|Y_)\\w+", nh_table) & !is.na(.collection_date) & !is.na(.container_version)){
     return(.nhanesTableVarsDB(data_group, nh_table, details, nchar, namesonly))
   }
 

--- a/R/nhanes_translate.R
+++ b/R/nhanes_translate.R
@@ -35,7 +35,7 @@
 nhanesTranslate <- function(nh_table, colnames=NULL, data = NULL, nchar = 128, 
                             mincategories = 2, details=FALSE, dxa=FALSE) {
 
-  if(dxa==FALSE & !is.na(.collection_date) & !is.na(.container_version)){
+  if(dxa==FALSE & !grepl("^(P_|Y_)\\w+", nh_table) & !is.na(.collection_date) & !is.na(.container_version)){
     return(.nhanesTranslateDB(nh_table, colnames,data,nchar,mincategories,details))
   }
 

--- a/man/nhanesSearch.Rd
+++ b/man/nhanesSearch.Rd
@@ -58,5 +58,5 @@ If no arguments are given, then nhanesSearch returns the complete variable list.
  \donttest{urin = nhanesSearch("urin", exclude_terms="During", ystart=2009)}
  \donttest{dim(urin)}
  \donttest{urine = nhanesSearch(c("urine", "urinary"), ignore.case=TRUE, ystop=2006, namesonly=TRUE)}
- \donttest{dim(urine)}
+ \donttest{length(urine)}
 }

--- a/vignettes/Introducing_nhanesA.R
+++ b/vignettes/Introducing_nhanesA.R
@@ -152,7 +152,7 @@ df
 #  dxx_c_s <- nhanesDXA(2003, suppl=TRUE)
 #  #Apply code translations
 #  dxalist <- c('DXAEXSTS', 'DXIHE')
-#  dxx_b <- nhanesTranslate(colnames=dxalist, data=dxx_b, dxa=TRUE)
+#  dxx_b <- nhanesTranslate("dxxb",colnames=dxalist, data=dxx_b, dxa=TRUE)
 
 ## ----nnyfs, eval=FALSE--------------------------------------------------------
 #  #List NNYFS EXAM tables

--- a/vignettes/Introducing_nhanesA.Rmd
+++ b/vignettes/Introducing_nhanesA.Rmd
@@ -249,7 +249,7 @@ nhanesDXA(2001, destfile="dxx_b.xpt")
 dxx_c_s <- nhanesDXA(2003, suppl=TRUE)
 #Apply code translations
 dxalist <- c('DXAEXSTS', 'DXIHE')
-dxx_b <- nhanesTranslate(colnames=dxalist, data=dxx_b, dxa=TRUE)
+dxx_b <- nhanesTranslate("dxxb",colnames=dxalist, data=dxx_b, dxa=TRUE)
 ```
 
 

--- a/vignettes/Introducing_nhanesA.html
+++ b/vignettes/Introducing_nhanesA.html
@@ -12,7 +12,7 @@
 
 <meta name="author" content="Christopher J. Endres" />
 
-<meta name="date" content="2023-09-14" />
+<meta name="date" content="2023-09-27" />
 
 <title>Introducing nhanesA</title>
 
@@ -340,7 +340,7 @@ code > span.er { color: #a61717; background-color: #e3d2d2; }
 
 <h1 class="title toc-ignore">Introducing nhanesA</h1>
 <h4 class="author">Christopher J. Endres</h4>
-<h4 class="date">2023-09-14</h4>
+<h4 class="date">2023-09-27</h4>
 
 
 
@@ -379,8 +379,8 @@ limited access data in nhanesA functions, use: - Limited (LTD)</p>
 <p>To quickly get familiar with NHANES data, it is helpful to display a
 listing of tables. Use nhanesTables to get information on tables that
 are available for a given category for a given year.</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(nhanesA)</span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTables</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="dv">2005</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" tabindex="-1"></a><span class="fu">library</span>(nhanesA)</span>
+<span id="cb1-2"><a href="#cb1-2" tabindex="-1"></a><span class="fu">nhanesTables</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="dv">2005</span>)</span></code></pre></div>
 <pre><code>##    Data.File.Name                             Data.File.Description
 ## 1           BPX_D                                    Blood Pressure
 ## 2           BMX_D                                     Body Measures
@@ -406,7 +406,7 @@ convenience, only a single 4-digit year is entered such that
 ‘BMX_D’ that contains body measures data. To better determine if that
 table is of interest, we can display detailed information on the table
 contents using nhanesTableVars.</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTableVars</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;BMX_D&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1" tabindex="-1"></a><span class="fu">nhanesTableVars</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;BMX_D&#39;</span>)</span></code></pre></div>
 <pre><code>##    Variable.Name                Variable.Description
 ## 1       BMDSTATS Body Measures Component status Code
 ## 2        BMIARMC           Arm Circumference Comment
@@ -441,15 +441,15 @@ identifier that is used to join information across tables.</p>
 <div id="import-nhanes-tables" class="section level3">
 <h3>Import NHANES Tables</h3>
 <p>We now import BMX_D along with the demographics table DEMO_D.</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>bmx_d  <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;BMX_D&#39;</span>)</span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>demo_d <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;DEMO_D&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" tabindex="-1"></a>bmx_d  <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;BMX_D&#39;</span>)</span>
+<span id="cb5-2"><a href="#cb5-2" tabindex="-1"></a>demo_d <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;DEMO_D&#39;</span>)</span></code></pre></div>
 <p>We merge the tables and display several variables. Note that
 RIAGENDR, like most categorical variables, is a coded field. By default,
 the original coded values (1,2) are translated to (Male, Female).</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>bmx_demo <span class="ot">&lt;-</span> <span class="fu">merge</span>(demo_d, bmx_d)</span>
-<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="fu">options</span>(<span class="at">digits=</span><span class="dv">4</span>)</span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>select_cols <span class="ot">&lt;-</span> <span class="fu">c</span>(<span class="st">&#39;RIAGENDR&#39;</span>, <span class="st">&#39;BMXHT&#39;</span>, <span class="st">&#39;BMXWT&#39;</span>, <span class="st">&#39;BMXLEG&#39;</span>, <span class="st">&#39;BMXCALF&#39;</span>, <span class="st">&#39;BMXTHICR&#39;</span>)</span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span>(bmx_demo[<span class="dv">5</span><span class="sc">:</span><span class="dv">8</span>,select_cols], <span class="at">row.names=</span><span class="cn">FALSE</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" tabindex="-1"></a>bmx_demo <span class="ot">&lt;-</span> <span class="fu">merge</span>(demo_d, bmx_d)</span>
+<span id="cb6-2"><a href="#cb6-2" tabindex="-1"></a><span class="fu">options</span>(<span class="at">digits=</span><span class="dv">4</span>)</span>
+<span id="cb6-3"><a href="#cb6-3" tabindex="-1"></a>select_cols <span class="ot">&lt;-</span> <span class="fu">c</span>(<span class="st">&#39;RIAGENDR&#39;</span>, <span class="st">&#39;BMXHT&#39;</span>, <span class="st">&#39;BMXWT&#39;</span>, <span class="st">&#39;BMXLEG&#39;</span>, <span class="st">&#39;BMXCALF&#39;</span>, <span class="st">&#39;BMXTHICR&#39;</span>)</span>
+<span id="cb6-4"><a href="#cb6-4" tabindex="-1"></a><span class="fu">print</span>(bmx_demo[<span class="dv">5</span><span class="sc">:</span><span class="dv">8</span>,select_cols], <span class="at">row.names=</span><span class="cn">FALSE</span>)</span></code></pre></div>
 <pre><code>##  RIAGENDR BMXHT BMXWT BMXLEG BMXCALF BMXTHICR
 ##    Female 156.0  75.2   38.0    36.6     53.7
 ##      Male 167.6  69.5   40.4    35.6     48.0
@@ -462,7 +462,7 @@ the original coded values (1,2) are translated to (Male, Female).</p>
 description of the variable and also includes the distribution or range
 of values. We can use nhanesCodebook to list the codebook definition for
 the gender field RIAGENDR in table DEMO_D.</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesCodebook</span>(<span class="st">&#39;DEMO_D&#39;</span>, <span class="st">&#39;RIAGENDR&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" tabindex="-1"></a><span class="fu">nhanesCodebook</span>(<span class="st">&#39;DEMO_D&#39;</span>, <span class="st">&#39;RIAGENDR&#39;</span>)</span></code></pre></div>
 <pre><code>## $`Variable Name`
 ## [1] &quot;RIAGENDR&quot;
 ## 
@@ -490,8 +490,8 @@ nhanesTranslate. Customized translation of coded fields is a three step
 process. 1: Download the table using nhanes with translate = FALSE 2:
 Select the table variables to translate 3: Pass the table and variable
 list to nhanesTranslate</p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>bpx_d <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;BPX_D&#39;</span>, <span class="at">translate=</span><span class="cn">FALSE</span>)</span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="fu">head</span>(bpx_d[,<span class="dv">6</span><span class="sc">:</span><span class="dv">11</span>])</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" tabindex="-1"></a>bpx_d <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;BPX_D&#39;</span>, <span class="at">translate=</span><span class="cn">FALSE</span>)</span>
+<span id="cb10-2"><a href="#cb10-2" tabindex="-1"></a><span class="fu">head</span>(bpx_d[,<span class="dv">6</span><span class="sc">:</span><span class="dv">11</span>])</span></code></pre></div>
 <pre><code>##   BPQ150A BPQ150B BPQ150C BPQ150D BPAARM BPACSZ
 ## 1      NA      NA      NA      NA     NA     NA
 ## 2       2       2       2       2      1      3
@@ -499,11 +499,11 @@ list to nhanesTranslate</p>
 ## 4       2       2       2       2      1      3
 ## 5       2       2       2       2      1      4
 ## 6       2       2       2       2      1      4</code></pre>
-<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a>bpx_d_vars  <span class="ot">&lt;-</span> <span class="fu">nhanesTableVars</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;BPX_D&#39;</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="co">#Alternatively may use bpx_d_vars = names(bpx_d)</span></span>
-<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>bpx_d <span class="ot">&lt;-</span> <span class="fu">nhanesTranslate</span>(<span class="st">&#39;BPX_D&#39;</span>, bpx_d_vars, <span class="at">data=</span>bpx_d)</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" tabindex="-1"></a>bpx_d_vars  <span class="ot">&lt;-</span> <span class="fu">nhanesTableVars</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;BPX_D&#39;</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
+<span id="cb12-2"><a href="#cb12-2" tabindex="-1"></a><span class="co">#Alternatively may use bpx_d_vars = names(bpx_d)</span></span>
+<span id="cb12-3"><a href="#cb12-3" tabindex="-1"></a>bpx_d <span class="ot">&lt;-</span> <span class="fu">nhanesTranslate</span>(<span class="st">&#39;BPX_D&#39;</span>, bpx_d_vars, <span class="at">data=</span>bpx_d)</span></code></pre></div>
 <pre><code>## Translated columns: BPAARM BPACSZ BPAEN2 BPAEN3 BPAEN4 BPQ150A BPQ150B BPQ150C BPQ150D BPXPTY BPXPULS PEASCCT1 PEASCST1</code></pre>
-<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="fu">head</span>(bpx_d[,<span class="dv">6</span><span class="sc">:</span><span class="dv">11</span>])</span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" tabindex="-1"></a><span class="fu">head</span>(bpx_d[,<span class="dv">6</span><span class="sc">:</span><span class="dv">11</span>])</span></code></pre></div>
 <pre><code>##   BPQ150A BPQ150B BPQ150C BPQ150D BPAARM        BPACSZ
 ## 1    &lt;NA&gt;    &lt;NA&gt;    &lt;NA&gt;    &lt;NA&gt;   &lt;NA&gt;          &lt;NA&gt;
 ## 2      No      No      No      No  Right Adult (12X22)
@@ -527,9 +527,9 @@ download entire surveys using nhanesA functions. Say we want to download
 every questionnaire in the 2007-2008 survey. We first get a list of the
 table names by using nhanesTables with namesonly = TRUE. The tables can
 then be downloaded using nhanes with lapply.</p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>q2007names  <span class="ot">&lt;-</span> <span class="fu">nhanesTables</span>(<span class="st">&#39;Q&#39;</span>, <span class="dv">2007</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>q2007tables <span class="ot">&lt;-</span> <span class="fu">lapply</span>(q2007names, nhanes)</span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a><span class="fu">names</span>(q2007tables) <span class="ot">&lt;-</span> q2007names</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb16-1"><a href="#cb16-1" tabindex="-1"></a>q2007names  <span class="ot">&lt;-</span> <span class="fu">nhanesTables</span>(<span class="st">&#39;Q&#39;</span>, <span class="dv">2007</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
+<span id="cb16-2"><a href="#cb16-2" tabindex="-1"></a>q2007tables <span class="ot">&lt;-</span> <span class="fu">lapply</span>(q2007names, nhanes)</span>
+<span id="cb16-3"><a href="#cb16-3" tabindex="-1"></a><span class="fu">names</span>(q2007tables) <span class="ot">&lt;-</span> q2007names</span></code></pre></div>
 </div>
 </div>
 <div id="special-cases" class="section level2">
@@ -550,16 +550,16 @@ of 2017-March 2020 pre-pandemic data. The table structure and variable
 format of pre-pandemic tables is essentially identical to standard
 continuous NHANES. The table names include the prefix “P_”. To list
 pre-pandemic tables, use ‘P’ or ‘p’ as the year.</p>
-<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="co">#List all pre-pandemic tables</span></span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearchTableNames</span>(<span class="st">&#39;^P_&#39;</span>)</span>
-<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a><span class="co">#List table variables</span></span>
-<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTableVars</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;P_AUX&#39;</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
-<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a><span class="co">#List pre-pandemic EXAM tables</span></span>
-<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTables</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;P&#39;</span>)</span>
-<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a><span class="co">#Table import, variable translation, and codebook display operate as usual</span></span>
-<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>p_dxxfem <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;P_DXXFEM&#39;</span>)</span>
-<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTranslate</span>(<span class="st">&#39;P_BMX&#39;</span>, <span class="st">&#39;BMDSTATS&#39;</span>)</span>
-<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesCodebook</span>(<span class="st">&#39;P_INS&#39;</span>, <span class="st">&#39;LBDINSI&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb17-1"><a href="#cb17-1" tabindex="-1"></a><span class="co">#List all pre-pandemic tables</span></span>
+<span id="cb17-2"><a href="#cb17-2" tabindex="-1"></a><span class="fu">nhanesSearchTableNames</span>(<span class="st">&#39;^P_&#39;</span>)</span>
+<span id="cb17-3"><a href="#cb17-3" tabindex="-1"></a><span class="co">#List table variables</span></span>
+<span id="cb17-4"><a href="#cb17-4" tabindex="-1"></a><span class="fu">nhanesTableVars</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;P_AUX&#39;</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
+<span id="cb17-5"><a href="#cb17-5" tabindex="-1"></a><span class="co">#List pre-pandemic EXAM tables</span></span>
+<span id="cb17-6"><a href="#cb17-6" tabindex="-1"></a><span class="fu">nhanesTables</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;P&#39;</span>)</span>
+<span id="cb17-7"><a href="#cb17-7" tabindex="-1"></a><span class="co">#Table import, variable translation, and codebook display operate as usual</span></span>
+<span id="cb17-8"><a href="#cb17-8" tabindex="-1"></a>p_dxxfem <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;P_DXXFEM&#39;</span>)</span>
+<span id="cb17-9"><a href="#cb17-9" tabindex="-1"></a><span class="fu">nhanesTranslate</span>(<span class="st">&#39;P_BMX&#39;</span>, <span class="st">&#39;BMDSTATS&#39;</span>)</span>
+<span id="cb17-10"><a href="#cb17-10" tabindex="-1"></a><span class="fu">nhanesCodebook</span>(<span class="st">&#39;P_INS&#39;</span>, <span class="st">&#39;LBDINSI&#39;</span>)</span></code></pre></div>
 </div>
 <div id="dual-energy-x-ray-absorptiometry" class="section level3">
 <h3>Dual Energy X-Ray Absorptiometry</h3>
@@ -573,15 +573,15 @@ to a local file then import to R as needed. When nhanesTranslate is
 applied to DXA data, only the 2005-2006 translation tables are used as
 those are the only DXA codes that are currently available in html
 format.</p>
-<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="co">#Import into R</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>dxx_b <span class="ot">&lt;-</span> <span class="fu">nhanesDXA</span>(<span class="dv">2001</span>)</span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="co">#Save to file</span></span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesDXA</span>(<span class="dv">2001</span>, <span class="at">destfile=</span><span class="st">&quot;dxx_b.xpt&quot;</span>)</span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="co">#Import supplemental data</span></span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>dxx_c_s <span class="ot">&lt;-</span> <span class="fu">nhanesDXA</span>(<span class="dv">2003</span>, <span class="at">suppl=</span><span class="cn">TRUE</span>)</span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="co">#Apply code translations</span></span>
-<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>dxalist <span class="ot">&lt;-</span> <span class="fu">c</span>(<span class="st">&#39;DXAEXSTS&#39;</span>, <span class="st">&#39;DXIHE&#39;</span>)</span>
-<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>dxx_b <span class="ot">&lt;-</span> <span class="fu">nhanesTranslate</span>(<span class="at">colnames=</span>dxalist, <span class="at">data=</span>dxx_b, <span class="at">dxa=</span><span class="cn">TRUE</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" tabindex="-1"></a><span class="co">#Import into R</span></span>
+<span id="cb18-2"><a href="#cb18-2" tabindex="-1"></a>dxx_b <span class="ot">&lt;-</span> <span class="fu">nhanesDXA</span>(<span class="dv">2001</span>)</span>
+<span id="cb18-3"><a href="#cb18-3" tabindex="-1"></a><span class="co">#Save to file</span></span>
+<span id="cb18-4"><a href="#cb18-4" tabindex="-1"></a><span class="fu">nhanesDXA</span>(<span class="dv">2001</span>, <span class="at">destfile=</span><span class="st">&quot;dxx_b.xpt&quot;</span>)</span>
+<span id="cb18-5"><a href="#cb18-5" tabindex="-1"></a><span class="co">#Import supplemental data</span></span>
+<span id="cb18-6"><a href="#cb18-6" tabindex="-1"></a>dxx_c_s <span class="ot">&lt;-</span> <span class="fu">nhanesDXA</span>(<span class="dv">2003</span>, <span class="at">suppl=</span><span class="cn">TRUE</span>)</span>
+<span id="cb18-7"><a href="#cb18-7" tabindex="-1"></a><span class="co">#Apply code translations</span></span>
+<span id="cb18-8"><a href="#cb18-8" tabindex="-1"></a>dxalist <span class="ot">&lt;-</span> <span class="fu">c</span>(<span class="st">&#39;DXAEXSTS&#39;</span>, <span class="st">&#39;DXIHE&#39;</span>)</span>
+<span id="cb18-9"><a href="#cb18-9" tabindex="-1"></a>dxx_b <span class="ot">&lt;-</span> <span class="fu">nhanesTranslate</span>(<span class="st">&quot;dxxb&quot;</span>,<span class="at">colnames=</span>dxalist, <span class="at">data=</span>dxx_b, <span class="at">dxa=</span><span class="cn">TRUE</span>)</span></code></pre></div>
 </div>
 <div id="nhanes-national-youth-fitness-survey-nnyfs" class="section level3">
 <h3>NHANES National Youth Fitness Survey (NNYFS)</h3>
@@ -590,11 +590,11 @@ and fitness levels of children and teens from ages 3-15. This study
 consists of questionnaires and basic measurements. There are no LAB
 tables. NNYFS table names include the prefix “Y_”. To list tables, use
 ‘Y’ or ‘y’ as the year.</p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="co">#List NNYFS EXAM tables</span></span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTables</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;Y&#39;</span>)</span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="co">#Table import and variable translation operate as usual</span></span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>y_cvx <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;Y_CVX&#39;</span>)</span>
-<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesTranslate</span>(<span class="st">&#39;Y_CVX&#39;</span>,<span class="st">&#39;CVXPARC&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb19-1"><a href="#cb19-1" tabindex="-1"></a><span class="co">#List NNYFS EXAM tables</span></span>
+<span id="cb19-2"><a href="#cb19-2" tabindex="-1"></a><span class="fu">nhanesTables</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;Y&#39;</span>)</span>
+<span id="cb19-3"><a href="#cb19-3" tabindex="-1"></a><span class="co">#Table import and variable translation operate as usual</span></span>
+<span id="cb19-4"><a href="#cb19-4" tabindex="-1"></a>y_cvx <span class="ot">&lt;-</span> <span class="fu">nhanes</span>(<span class="st">&#39;Y_CVX&#39;</span>)</span>
+<span id="cb19-5"><a href="#cb19-5" tabindex="-1"></a><span class="fu">nhanesTranslate</span>(<span class="st">&#39;Y_CVX&#39;</span>,<span class="st">&#39;CVXPARC&#39;</span>)</span></code></pre></div>
 </div>
 </div>
 <div id="searching-for-tables-and-variables" class="section level2">
@@ -615,26 +615,26 @@ must contain one of the terms) and exclusive search terms (variable
 descriptions must NOT contain any exclusive terms) may be provided. The
 search can be restricted to a specific survey range as well as specific
 data groups.</p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="co"># nhanesSearch use examples</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="co">#</span></span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Search on the word bladder, restrict to the 2001-2008 surveys, </span></span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a><span class="co"># print out 50 characters of the variable description</span></span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;bladder&quot;</span>, <span class="at">ystart=</span><span class="dv">2001</span>, <span class="at">ystop=</span><span class="dv">2008</span>, <span class="at">nchar=</span><span class="dv">50</span>)</span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a><span class="co">#</span></span>
-<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="co"># Search on &quot;urin&quot; (will match urine, urinary, etc), from 1999-2010, return table names only</span></span>
-<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;urin&quot;</span>, <span class="at">ignore.case=</span><span class="cn">TRUE</span>, <span class="at">ystop=</span><span class="dv">2010</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
-<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a><span class="co">#</span></span>
-<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a><span class="co"># Search on &quot;urin&quot;, exclude &quot;During&quot;, search surveys from 1999-2010, return table names only</span></span>
-<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;urin&quot;</span>, <span class="at">exclude_terms=</span><span class="st">&quot;during&quot;</span>, <span class="at">ignore.case=</span><span class="cn">TRUE</span>, <span class="at">ystop=</span><span class="dv">2010</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
-<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a><span class="co">#</span></span>
-<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a><span class="co"># Restrict search to &#39;EXAM&#39; and &#39;LAB&#39; data groups. Explicitly list matching and exclude terms, leave ignore.case set to default value of FALSE. Search surveys from 2009 to present.</span></span>
-<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="fu">c</span>(<span class="st">&quot;urin&quot;</span>, <span class="st">&quot;Urin&quot;</span>), <span class="at">exclude_terms=</span><span class="fu">c</span>(<span class="st">&quot;During&quot;</span>, <span class="st">&quot;eaten during&quot;</span>, <span class="st">&quot;do during&quot;</span>), <span class="at">data_group=</span><span class="fu">c</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;LAB&#39;</span>), <span class="at">ystart=</span><span class="dv">2009</span>)</span>
-<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a><span class="co">#</span></span>
-<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a><span class="co"># Search on &quot;tooth&quot; or &quot;teeth&quot;, all years</span></span>
-<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="fu">c</span>(<span class="st">&quot;tooth&quot;</span>, <span class="st">&quot;teeth&quot;</span>), <span class="at">ignore.case=</span><span class="cn">TRUE</span>)</span>
-<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a><span class="co">#</span></span>
-<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a><span class="co"># Search for variables where the variable description begins with &quot;Tooth&quot;</span></span>
-<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;^Tooth&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" tabindex="-1"></a><span class="co"># nhanesSearch use examples</span></span>
+<span id="cb20-2"><a href="#cb20-2" tabindex="-1"></a><span class="co">#</span></span>
+<span id="cb20-3"><a href="#cb20-3" tabindex="-1"></a><span class="co"># Search on the word bladder, restrict to the 2001-2008 surveys, </span></span>
+<span id="cb20-4"><a href="#cb20-4" tabindex="-1"></a><span class="co"># print out 50 characters of the variable description</span></span>
+<span id="cb20-5"><a href="#cb20-5" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;bladder&quot;</span>, <span class="at">ystart=</span><span class="dv">2001</span>, <span class="at">ystop=</span><span class="dv">2008</span>, <span class="at">nchar=</span><span class="dv">50</span>)</span>
+<span id="cb20-6"><a href="#cb20-6" tabindex="-1"></a><span class="co">#</span></span>
+<span id="cb20-7"><a href="#cb20-7" tabindex="-1"></a><span class="co"># Search on &quot;urin&quot; (will match urine, urinary, etc), from 1999-2010, return table names only</span></span>
+<span id="cb20-8"><a href="#cb20-8" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;urin&quot;</span>, <span class="at">ignore.case=</span><span class="cn">TRUE</span>, <span class="at">ystop=</span><span class="dv">2010</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
+<span id="cb20-9"><a href="#cb20-9" tabindex="-1"></a><span class="co">#</span></span>
+<span id="cb20-10"><a href="#cb20-10" tabindex="-1"></a><span class="co"># Search on &quot;urin&quot;, exclude &quot;During&quot;, search surveys from 1999-2010, return table names only</span></span>
+<span id="cb20-11"><a href="#cb20-11" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;urin&quot;</span>, <span class="at">exclude_terms=</span><span class="st">&quot;during&quot;</span>, <span class="at">ignore.case=</span><span class="cn">TRUE</span>, <span class="at">ystop=</span><span class="dv">2010</span>, <span class="at">namesonly=</span><span class="cn">TRUE</span>)</span>
+<span id="cb20-12"><a href="#cb20-12" tabindex="-1"></a><span class="co">#</span></span>
+<span id="cb20-13"><a href="#cb20-13" tabindex="-1"></a><span class="co"># Restrict search to &#39;EXAM&#39; and &#39;LAB&#39; data groups. Explicitly list matching and exclude terms, leave ignore.case set to default value of FALSE. Search surveys from 2009 to present.</span></span>
+<span id="cb20-14"><a href="#cb20-14" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="fu">c</span>(<span class="st">&quot;urin&quot;</span>, <span class="st">&quot;Urin&quot;</span>), <span class="at">exclude_terms=</span><span class="fu">c</span>(<span class="st">&quot;During&quot;</span>, <span class="st">&quot;eaten during&quot;</span>, <span class="st">&quot;do during&quot;</span>), <span class="at">data_group=</span><span class="fu">c</span>(<span class="st">&#39;EXAM&#39;</span>, <span class="st">&#39;LAB&#39;</span>), <span class="at">ystart=</span><span class="dv">2009</span>)</span>
+<span id="cb20-15"><a href="#cb20-15" tabindex="-1"></a><span class="co">#</span></span>
+<span id="cb20-16"><a href="#cb20-16" tabindex="-1"></a><span class="co"># Search on &quot;tooth&quot; or &quot;teeth&quot;, all years</span></span>
+<span id="cb20-17"><a href="#cb20-17" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="fu">c</span>(<span class="st">&quot;tooth&quot;</span>, <span class="st">&quot;teeth&quot;</span>), <span class="at">ignore.case=</span><span class="cn">TRUE</span>)</span>
+<span id="cb20-18"><a href="#cb20-18" tabindex="-1"></a><span class="co">#</span></span>
+<span id="cb20-19"><a href="#cb20-19" tabindex="-1"></a><span class="co"># Search for variables where the variable description begins with &quot;Tooth&quot;</span></span>
+<span id="cb20-20"><a href="#cb20-20" tabindex="-1"></a><span class="fu">nhanesSearch</span>(<span class="st">&quot;^Tooth&quot;</span>)</span></code></pre></div>
 </div>
 <div id="searching-for-tables-that-contain-a-specific-variable" class="section level3">
 <h3>Searching for tables that contain a specific variable</h3>
@@ -649,11 +649,11 @@ then only the matching elements are converted to a data frame.
 Consequently, a call to nhanesSearchVarName executes much faster than
 nhanesSearch; typically under 30s. nhanesSearchVarName is useful for
 finding all data tables that contain a given variable.</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="co">#nhanesSearchVarName use examples</span></span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearchVarName</span>(<span class="st">&#39;BPXPULS&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb21-1"><a href="#cb21-1" tabindex="-1"></a><span class="co">#nhanesSearchVarName use examples</span></span>
+<span id="cb21-2"><a href="#cb21-2" tabindex="-1"></a><span class="fu">nhanesSearchVarName</span>(<span class="st">&#39;BPXPULS&#39;</span>)</span></code></pre></div>
 <pre><code>##  [1] &quot;BPX_D&quot; &quot;BPX_E&quot; &quot;BPX&quot;   &quot;BPX_C&quot; &quot;BPX_B&quot; &quot;BPX_F&quot; &quot;BPX_G&quot; &quot;BPX_H&quot; &quot;BPX_I&quot;
 ## [10] &quot;BPX_J&quot;</code></pre>
-<div class="sourceCode" id="cb23"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearchVarName</span>(<span class="st">&#39;CSQ260i&#39;</span>, <span class="at">includerdc=</span><span class="cn">TRUE</span>, <span class="at">nchar=</span><span class="dv">38</span>, <span class="at">namesonly=</span><span class="cn">FALSE</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb23-1"><a href="#cb23-1" tabindex="-1"></a><span class="fu">nhanesSearchVarName</span>(<span class="st">&#39;CSQ260i&#39;</span>, <span class="at">includerdc=</span><span class="cn">TRUE</span>, <span class="at">nchar=</span><span class="dv">38</span>, <span class="at">namesonly=</span><span class="cn">FALSE</span>)</span></code></pre></div>
 <pre><code>##   Variable.Name                   Variable.Description Data.File.Name
 ## 1       CSQ260i Do you now have any of the following p        CSX_G_R
 ## 2       CSQ260i Do you now have any of the following p          CSX_H
@@ -671,11 +671,11 @@ the full list of available tables with nhanesSearchTableNames(‘BMX’).
 The search is conducted over the comprehensive table list, which is much
 smaller than the comprehensive variable list, such that a call to
 nhanesSearchTableNames takes only a few seconds.</p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="co"># nhanesSearchTableNames use examples</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearchTableNames</span>(<span class="st">&#39;BMX&#39;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb25-1"><a href="#cb25-1" tabindex="-1"></a><span class="co"># nhanesSearchTableNames use examples</span></span>
+<span id="cb25-2"><a href="#cb25-2" tabindex="-1"></a><span class="fu">nhanesSearchTableNames</span>(<span class="st">&#39;BMX&#39;</span>)</span></code></pre></div>
 <pre><code>##  [1] &quot;BMX_D&quot; &quot;BMX&quot;   &quot;BMX_E&quot; &quot;BMX_C&quot; &quot;BMX_B&quot; &quot;BMX_F&quot; &quot;BMX_H&quot; &quot;BMX_G&quot; &quot;BMX_I&quot;
 ## [10] &quot;BMX_J&quot; &quot;P_BMX&quot;</code></pre>
-<div class="sourceCode" id="cb27"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">nhanesSearchTableNames</span>(<span class="st">&#39;HPVS&#39;</span>, <span class="at">includerdc=</span><span class="cn">TRUE</span>, <span class="at">nchar=</span><span class="dv">42</span>, <span class="at">details=</span><span class="cn">TRUE</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb27-1"><a href="#cb27-1" tabindex="-1"></a><span class="fu">nhanesSearchTableNames</span>(<span class="st">&#39;HPVS&#39;</span>, <span class="at">includerdc=</span><span class="cn">TRUE</span>, <span class="at">nchar=</span><span class="dv">42</span>, <span class="at">details=</span><span class="cn">TRUE</span>)</span></code></pre></div>
 <pre><code>##        Years                             Data.File.Name     Doc.File
 ## 1  2009-2010 Human Papillomavirus (HPV) - 6, 11, 16 &amp; 1 HPVSER_F Doc
 ## 2  2005-2006 Human Papillomavirus (HPV) - 6, 11, 16 &amp; 1 HPVS_D_R Doc


### PR DESCRIPTION
1. exclude  P and Y tables from DB version functions because we do not have those in our DB.

2. Fixed minor issue in the vignette page.

Fixed the below issue.
```R
> dxx_b <- nhanesTranslate(colnames=dxalist, data=dxx_b, dxa=TRUE)
Error in nhanesTranslate(colnames = dxalist, data = dxx_b, dxa = TRUE) :
  argument "nh_table" is missing, with no default
```