### PR TITLE
add data download sizes to manifest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,9 +26,7 @@ Imports:
     rvest,
     magrittr,
     xml2,
-    plyr,
-    DBI,
-    odbc
+    plyr
 Description: Utility to retrieve data from the National Health and Nutrition 
 	Examination Survey (NHANES) website <https://www.cdc.gov/nchs/nhanes/index.htm>.
 License: GPL (>= 2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,19 +26,20 @@ Imports:
     rvest,
     magrittr,
     xml2,
-    plyr
+    plyr,
+    DBI,
+    odbc
 Description: Utility to retrieve data from the National Health and Nutrition 
 	Examination Survey (NHANES) website <https://www.cdc.gov/nchs/nhanes/index.htm>.
 License: GPL (>= 2)
 Encoding: UTF-8
 URL: https://cran.r-project.org/package=nhanesA
-Packaged: 2015-10-07 18:15:14 UTC; Endres
 Suggests:
     knitr,
     odbc,
     DBI,
     rmarkdown,
-	survey,
-	ggplot2
+    survey,
+    ggplot2
 VignetteBuilder: knitr
 RoxygenNote: 7.2.3

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,8 +24,7 @@ cn = function() .datacache$cn
       server = "localhost", 
       database = "NhanesLandingZone",
       port = 1433, 
-      driver = "ODBC Driver 17 for SQL Server"
-    )
+      driver = "ODBC Driver 17 for SQL Server")
     
     after <- getTaskCallbackNames()
     removeTaskCallback(which(!after %in% before))
@@ -48,6 +47,6 @@ cn = function() .datacache$cn
 .onUnload <- function(libpath)
 {
   if(!is.na(.container_version) & !is.na(.collection_date)){
-    DBI::dbDisconnect(cn)
+    DBI::dbDisconnect(cn())
   }
 }

--- a/man/nhanesManifest.Rd
+++ b/man/nhanesManifest.Rd
@@ -2,25 +2,33 @@
 % Please edit documentation in R/nhanes_tables.R
 \name{nhanesManifest}
 \alias{nhanesManifest}
-\title{Returns the entire NHANES manifest}
+\title{Download and parse the entire NHANES manifest}
 \usage{
-nhanesManifest(which = "Tables")
+nhanesManifest(which = "Tables", sizes = TRUE, verbose = getOption("verbose"))
 }
 \arguments{
 \item{which}{Either "Tables" or "Variables"}
+
+\item{sizes}{Logical, whether to compute data file sizes (as
+reported by the server) and include them in the result.}
+
+\item{verbose}{Logical flag indicating whether information on
+progress should be reported.}
 }
 \value{
-When "Tables" is specified it returns a data.frame with one row for 
-each NHANES data table, with columns "Table", "DocURL", "DataURL", "Years", "Date.Published"
+When "Tables" is specified it returns a data.frame with
+    one row for each NHANES data table, with columns "Table",
+    "DocURL", "DataURL", "Years", "Date.Published". If \code{sizes
+    = TRUE}, an additional column "DataSize" giving the data file
+    sizes in bytes (as reported by the server) is included.
 }
 \description{
-Returns the entire NHANES manifest
-}
-\details{
-Will download the comprehensive manifest of variables or tables
+Downloads and parses the NHANES manifest available at
+\url{https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx} and
+returns it as a data frame.
 }
 \examples{
-manifest = nhanesManifest()
+manifest <- nhanesManifest(sizes = FALSE)
 dim(manifest)
 
 }


### PR DESCRIPTION
This patch adds new argument in `nhanesManifest(sizes = )` that, when set to `TRUE`, will add file size information to the returned manifest. 