### PR TITLE
Support for alternative data sources

### DIFF
--- a/R/nhanes_codebook.R
+++ b/R/nhanes_codebook.R
@@ -12,9 +12,13 @@
 #' @param nh_table The name of the NHANES table that contains the desired variable.
 #' @param colname The name of the table column (variable).
 #' @param dxa If TRUE then the 2005-2006 DXA codebook will be used (default=FALSE).
-#' @details Each NHANES variable has a codebook that provides a basic description
-#' as well as the distribution or range of values. This function returns the full
-#' codebook information for the selected variable.
+#' @details Each NHANES variable has a codebook that provides a basic
+#'   description as well as the distribution or range of values. This
+#'   function returns the full codebook information for the selected
+#'   variable. If the environment variable \code{NHANES_TABLE_BASE}
+#'   was set during startup, the value of this variable is used as the
+#'   base URL instead of \url{https://wwwn.cdc.gov} (this allows the
+#'   use of a local or alternative mirror of the CDC documentation).
 #' @return The codebook is returned as a list object. Returns NULL upon error.
 #' @examples
 #' \donttest{nhanesCodebook('AUX_D', 'AUQ020D')}
@@ -32,7 +36,6 @@ nhanesCodebook <- function(nh_table, colname=NULL, dxa=FALSE) {
     return(.nhanesCodebookDB(nh_table, colname))
   }
   
-
   if(dxa) {
     url <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/dxx_d.htm"
   } else {  nh_year <- .get_year_from_nh_table(nh_table)
@@ -42,7 +45,7 @@ nhanesCodebook <- function(nh_table, colname=NULL, dxa=FALSE) {
   if(nh_year == "Nnyfs"){
     url <- str_c("https://wwwn.cdc.gov/Nchs/", nh_year, '/', nh_table, '.htm', sep='')
   } else {
-    url <- str_c(nhanesURL, nh_year, '/', nh_table, '.htm', sep='')
+    url <- str_c(nhanesTableURL, nh_year, '/', nh_table, '.htm', sep='')
   }
   }
   hurl <- .checkHtml(url)

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -1,4 +1,8 @@
 # nhanes_constants.R
+
+## This may be overwritten in .onLoad() (see zzz.R)
+nhanesTableURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
+
 nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 dataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx'
 dxaURL  <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/"

--- a/R/nhanes_translate.R
+++ b/R/nhanes_translate.R
@@ -11,19 +11,33 @@
 #' @importFrom xml2 read_html
 #' @importFrom plyr mapvalues
 #' @param nh_table The name of the NHANES table to retrieve.
-#' @param colnames The names of the columns to translate. It will translate all the columns by default.
-#' @param data If a data frame is passed, then code translation will be applied directly to the data frame. \cr
-#' In that case the return argument is the code-translated data frame.
-#' @param nchar Applies only when data is defined. Code translations can be very long. \cr
-#' Truncate the length by setting nchar (default = 128).
-#' @param mincategories The minimum number of categories needed for code translations to be applied to the data (default=2).
-#' @param details If TRUE then all available table translation information is displayed (default=FALSE).
-#' @param dxa If TRUE then the 2005-2006 DXA translation table will be used (default=FALSE).
-#' @return The code translation table (or translated data frame when data is defined). Returns NULL upon error.
-#' @details Most NHANES data tables have encoded values. E.g. 1 = 'Male', 2 = 'Female'.
-#' Thus it is often helpful to view the code translations and perhaps insert the translated values
-#' in a data frame. Only a single table may be specified, but multiple variables within that table
-#' can be selected. Code translations are retrieved for each variable. 
+#' @param colnames The names of the columns to translate. It will
+#'   translate all the columns by default.
+#' @param data If a data frame is passed, then code translation will
+#'   be applied directly to the data frame. \cr In that case the
+#'   return argument is the code-translated data frame.
+#' @param nchar Applies only when data is defined. Code translations
+#'   can be very long. \cr Truncate the length by setting nchar
+#'   (default = 128).
+#' @param mincategories The minimum number of categories needed for
+#'   code translations to be applied to the data (default=2).
+#' @param details If TRUE then all available table translation
+#'   information is displayed (default=FALSE).
+#' @param dxa If TRUE then the 2005-2006 DXA translation table will be
+#'   used (default=FALSE).
+#'
+#' @return The code translation table (or translated data frame when
+#'   data is defined). Returns NULL upon error.
+#' @details Most NHANES data tables have encoded values. E.g. 1 =
+#'   'Male', 2 = 'Female'.  Thus it is often helpful to view the code
+#'   translations and perhaps insert the translated values in a data
+#'   frame. Only a single table may be specified, but multiple
+#'   variables within that table can be selected. Code translations
+#'   are retrieved for each variable. If the environment variable
+#'   \code{NHANES_TABLE_BASE} was set during startup, the value of
+#'   this variable is used as the base URL instead of
+#'   \url{https://wwwn.cdc.gov} (this allows the use of a local or
+#'   alternative mirror of the CDC documentation).
 #' @examples
 #' \donttest{nhanesTranslate('DEMO_B', c('DMDBORN','DMDCITZN'))}
 #' \donttest{nhanesTranslate('BPX_F', 'BPACSZ', details=TRUE)}
@@ -113,7 +127,7 @@ nhanesTranslate <- function(nh_table, colnames=NULL, data = NULL, nchar = 128,
     if(nh_year == "Nnyfs"){
       code_translation_url <- str_c("https://wwwn.cdc.gov/Nchs/", nh_year, '/', nh_table, '.htm', sep='')
     } else {
-      code_translation_url <- str_c(nhanesURL, nh_year, '/', nh_table, '.htm', sep='')
+      code_translation_url <- str_c(nhanesTableURL, nh_year, '/', nh_table, '.htm', sep='')
     }
   }
   hurl <- .checkHtml(code_translation_url)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -40,7 +40,7 @@ validTables <- function() .dbEnv$validTables
       uid = Sys.getenv("EPICONDUCTOR_DB_UID", unset = "sa"),
       pwd = Sys.getenv("EPICONDUCTOR_DB_PWD", unset = "yourStrong(!)Password"),
       server = Sys.getenv("EPICONDUCTOR_DB_SERVER", unset = "localhost"),
-      port = as.integer(Sys.getenv("EPICONDUCTOR_DB_SERVER", unset = "1433")),
+      port = as.integer(Sys.getenv("EPICONDUCTOR_DB_PORT", unset = "1433")),
       database = Sys.getenv("EPICONDUCTOR_DB_DATABASE", unset = "NhanesLandingZone"),
       driver = Sys.getenv("EPICONDUCTOR_DB_DRIVER", unset = "ODBC Driver 17 for SQL Server")
     )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -71,6 +71,9 @@ validTables <- function() .dbEnv$validTables
 .onLoad = function(libname, pkgname)
 {
   nhanesOptions(use.db = .init_db())
+  nhanesTableBASE <- Sys.getenv("NHANES_TABLE_BASE")
+  if (nzchar(nhanesTableBASE))
+      nhanesTableURL <<- paste0(nhanesTableBASE, '/Nchs/Nhanes/')
 }
 
 .onUnload <- function(libpath)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -36,13 +36,13 @@ validTables <- function() .dbEnv$validTables
   before <- getTaskCallbackNames()
   .dbEnv$cn <-
     DBI::dbConnect(
-      odbc::odbc(), 
-      uid = "sa", 
-      pwd = "yourStrong(!)Password",
-      server = "localhost", 
-      database = "NhanesLandingZone",
-      port = 1433, 
-      driver = "ODBC Driver 17 for SQL Server"
+      odbc::odbc(),
+      uid = Sys.getenv("EPICONDUCTOR_DB_UID", unset = "sa"),
+      pwd = Sys.getenv("EPICONDUCTOR_DB_PWD", unset = "yourStrong(!)Password"),
+      server = Sys.getenv("EPICONDUCTOR_DB_SERVER", unset = "localhost"),
+      port = as.integer(Sys.getenv("EPICONDUCTOR_DB_SERVER", unset = "1433")),
+      database = Sys.getenv("EPICONDUCTOR_DB_DATABASE", unset = "NhanesLandingZone"),
+      driver = Sys.getenv("EPICONDUCTOR_DB_DRIVER", unset = "ODBC Driver 17 for SQL Server")
     )
     after <- getTaskCallbackNames()
     removeTaskCallback(which(!after %in% before))

--- a/man/browseNHANES.Rd
+++ b/man/browseNHANES.Rd
@@ -4,27 +4,45 @@
 \alias{browseNHANES}
 \title{Open a browser to NHANES.}
 \usage{
-browseNHANES(year = NULL, data_group = NULL, nh_table = NULL)
+browseNHANES(
+  year = NULL,
+  data_group = NULL,
+  nh_table = NULL,
+  local = TRUE,
+  browse = TRUE
+)
 }
 \arguments{
 \item{year}{The year in yyyy format where 1999 <= yyyy.}
 
-\item{data_group}{The type of survey (DEMOGRAPHICS, DIETARY, EXAMINATION, LABORATORY, QUESTIONNAIRE).
-Abbreviated terms may also be used: (DEMO, DIET, EXAM, LAB, Q).}
+\item{data_group}{The type of survey (DEMOGRAPHICS, DIETARY,
+EXAMINATION, LABORATORY, QUESTIONNAIRE).  Abbreviated terms may
+also be used: (DEMO, DIET, EXAM, LAB, Q).}
 
 \item{nh_table}{The name of an NHANES table.}
+
+\item{local}{logical flag. If \code{TRUE}, and a local or
+alternative source was specificed using the environment variable
+\code{NHANES_TABLE_BASE}, this will be used in preference to the
+CDC website at \url{https://wwwn.cdc.gov} for named tables.}
+
+\item{browse}{logical flag, indicating whether the specific NHANES
+site should be opened using a browser (which is the default
+behaviour).}
 }
 \value{
-No return value
+A character string giving the URL, invisibly if the URL is
+  also opened using \code{\link{browseURL}}.
 }
 \description{
 The browser may be directed to a specific year, survey, or table.
 }
 \details{
-browseNHANES will open a web browser to the specified NHANES site.
+By default, browseNHANES will open a web browser to the
+  specified NHANES site.
 }
 \examples{
-browseNHANES()                     # Defaults to the main data sets page
+browseNHANES(browse = FALSE)       # Defaults to the main data sets page
 browseNHANES(2005)                 # The main page for the specified survey year
 browseNHANES(2009, 'EXAM')         # Page for the specified year and survey group
 browseNHANES(nh_table = 'VIX_D')   # Page for a specific table

--- a/man/nhanes.Rd
+++ b/man/nhanes.Rd
@@ -9,11 +9,13 @@ nhanes(nh_table, includelabels = FALSE, translated = TRUE, nchar = 128)
 \arguments{
 \item{nh_table}{The name of the specific table to retrieve.}
 
-\item{includelabels}{If TRUE, then include SAS labels as variable attribute (default = FALSE).}
+\item{includelabels}{If TRUE, then include SAS labels as variable
+attribute (default = FALSE).}
 
 \item{translated}{translated whether the variables are translated.}
 
-\item{nchar}{Maximum length of translated string (default = 128). Ignored if translated=FALSE.}
+\item{nchar}{Maximum length of translated string (default =
+128). Ignored if translated=FALSE.}
 }
 \value{
 The table is returned as a data frame.
@@ -22,11 +24,15 @@ The table is returned as a data frame.
 Use to download NHANES data tables that are in SAS format.
 }
 \details{
-Downloads a table from the NHANES website as is, i.e. in its entirety
-with no modification or cleansing. NHANES tables 
-are stored in SAS '.XPT' format but are imported as a data frame.
-Function nhanes cannot be used to import limited 
-access data.
+Downloads a table from the NHANES website as is, i.e. in
+  its entirety with no modification or cleansing. If the
+  environment variable \code{NHANES_TABLE_BASE} was set during
+  startup, the value of this variable is used as the base URL
+  instead of \url{https://wwwn.cdc.gov} (this allows the use of a
+  local or alternative mirror of the CDC data). NHANES tables are
+  stored in SAS '.XPT' format but are imported as a data frame.
+  The \code{nhanes} function cannot be used to import limited
+  access data.
 }
 \examples{
 \donttest{bpx_e = nhanes('BPX_E')}

--- a/man/nhanesAttr.Rd
+++ b/man/nhanesAttr.Rd
@@ -24,9 +24,16 @@ Returns attributes such as number of rows, columns, and memory size,
 but does not return the table itself.
 }
 \details{
-nhanesAttr allows one to check the size and other charactersistics of a data table 
-before importing into R. To retrieve these characteristics, the specified table is downloaded,
-characteristics are determined, then the table is deleted.
+nhanesAttr allows one to check the size and other
+  charactersistics of a data table before importing into R. To
+  retrieve these characteristics, the specified table is
+  downloaded, characteristics are determined, then the table is
+  deleted. Downloads a table from the NHANES website as is, i.e. in
+  its entirety with no modification or cleansing. If the
+  environment variable \code{NHANES_TABLE_BASE} was set during
+  startup, the value of this variable is used as the base URL
+  instead of \url{https://wwwn.cdc.gov} (this allows the use of a
+  local or alternative mirror of the CDC data).
 }
 \examples{
 nhanesAttr('BPX_E')

--- a/man/nhanesCodebook.Rd
+++ b/man/nhanesCodebook.Rd
@@ -21,9 +21,13 @@ Returns full NHANES codebook including Variable Name, SAS Label, English Text, T
 and Value distribution.
 }
 \details{
-Each NHANES variable has a codebook that provides a basic description
-as well as the distribution or range of values. This function returns the full
-codebook information for the selected variable.
+Each NHANES variable has a codebook that provides a basic
+  description as well as the distribution or range of values. This
+  function returns the full codebook information for the selected
+  variable. If the environment variable \code{NHANES_TABLE_BASE}
+  was set during startup, the value of this variable is used as the
+  base URL instead of \url{https://wwwn.cdc.gov} (this allows the
+  use of a local or alternative mirror of the CDC documentation).
 }
 \examples{
 \donttest{nhanesCodebook('AUX_D', 'AUQ020D')}

--- a/man/nhanesTranslate.Rd
+++ b/man/nhanesTranslate.Rd
@@ -17,32 +17,45 @@ nhanesTranslate(
 \arguments{
 \item{nh_table}{The name of the NHANES table to retrieve.}
 
-\item{colnames}{The names of the columns to translate. It will translate all the columns by default.}
+\item{colnames}{The names of the columns to translate. It will
+translate all the columns by default.}
 
-\item{data}{If a data frame is passed, then code translation will be applied directly to the data frame. \cr
-In that case the return argument is the code-translated data frame.}
+\item{data}{If a data frame is passed, then code translation will
+be applied directly to the data frame. \cr In that case the
+return argument is the code-translated data frame.}
 
-\item{nchar}{Applies only when data is defined. Code translations can be very long. \cr
-Truncate the length by setting nchar (default = 128).}
+\item{nchar}{Applies only when data is defined. Code translations
+can be very long. \cr Truncate the length by setting nchar
+(default = 128).}
 
-\item{mincategories}{The minimum number of categories needed for code translations to be applied to the data (default=2).}
+\item{mincategories}{The minimum number of categories needed for
+code translations to be applied to the data (default=2).}
 
-\item{details}{If TRUE then all available table translation information is displayed (default=FALSE).}
+\item{details}{If TRUE then all available table translation
+information is displayed (default=FALSE).}
 
-\item{dxa}{If TRUE then the 2005-2006 DXA translation table will be used (default=FALSE).}
+\item{dxa}{If TRUE then the 2005-2006 DXA translation table will be
+used (default=FALSE).}
 }
 \value{
-The code translation table (or translated data frame when data is defined). Returns NULL upon error.
+The code translation table (or translated data frame when
+  data is defined). Returns NULL upon error.
 }
 \description{
 Returns code translations for categorical variables, 
 which appear in most NHANES tables.
 }
 \details{
-Most NHANES data tables have encoded values. E.g. 1 = 'Male', 2 = 'Female'.
-Thus it is often helpful to view the code translations and perhaps insert the translated values
-in a data frame. Only a single table may be specified, but multiple variables within that table
-can be selected. Code translations are retrieved for each variable.
+Most NHANES data tables have encoded values. E.g. 1 =
+  'Male', 2 = 'Female'.  Thus it is often helpful to view the code
+  translations and perhaps insert the translated values in a data
+  frame. Only a single table may be specified, but multiple
+  variables within that table can be selected. Code translations
+  are retrieved for each variable. If the environment variable
+  \code{NHANES_TABLE_BASE} was set during startup, the value of
+  this variable is used as the base URL instead of
+  \url{https://wwwn.cdc.gov} (this allows the use of a local or
+  alternative mirror of the CDC documentation).
 }
 \examples{
 \donttest{nhanesTranslate('DEMO_B', c('DMDBORN','DMDCITZN'))}


### PR DESCRIPTION
This PR adds support for environment variables controlling data sources, of two types:

- Several `EPICONDUCTOR_DB_*` variables to control details of a database, if available. This allows connecting to a database that's not necessarily running on the local machine.
- The `NHANES_TABLE_BASE` env var can be specified as an alternative to the CDC site <https://wwwn.cdc.gov> to point to local / alternative copies of documentation and data files.