### PR TITLE
Add local caching option using BiocFileCache 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     DBI,
     rmarkdown,
     survey,
-    ggplot2
+    ggplot2,
+    BiocFileCache
 VignetteBuilder: knitr
 RoxygenNote: 7.2.3

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -53,7 +53,7 @@ nhanes <- function(nh_table, includelabels = FALSE, translated = TRUE, nchar = 1
     
     tf <- tempfile()
     if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
-    download.file(url, tf, mode = "wb", quiet = TRUE)
+    download.file(.wrapURL(url), tf, mode = "wb", quiet = TRUE)
     
     nh_df <- read.xport(tf)
 
@@ -114,7 +114,7 @@ nhanesFromURL <- function(url, translated = TRUE, nchar = 128)
   tryCatch({    
     tf <- tempfile()
     if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
-    download.file(url, tf, mode = "wb", quiet = TRUE)
+    download.file(.wrapURL(url), tf, mode = "wb", quiet = TRUE)
     nh_df <- read.xport(tf)
     if (translated) {
       ## guess table name
@@ -184,7 +184,8 @@ nhanesDXA <- function(year, suppl=FALSE, destfile=NULL) {
       url <- paste0(dxaURL, fname, '.xpt')
       if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
       if(!is.null(destfile)) {
-        ok <- suppressWarnings(tryCatch({download.file(url, destfile, mode="wb", quiet=TRUE)},
+        ok <- suppressWarnings(tryCatch({download.file(.wrapURL(url), destfile,
+                                                       mode="wb", quiet=TRUE)},
                                         error=function(cond){message(cond); return(NULL)}))         
         return(ok)
       } else {
@@ -246,7 +247,7 @@ nhanesAttr <- function(nh_table) {
     
     tf <- tempfile()
     if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
-    download.file(url, tf, mode = "wb", quiet = TRUE)
+    download.file(.wrapURL(url), tf, mode = "wb", quiet = TRUE)
     
 #    tmp <- read.xport(tf)
     xport_struct <- lookup.xport(tf)

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -307,10 +307,8 @@ nhanesAttr <- function(nh_table) {
 #'   EXAMINATION, LABORATORY, QUESTIONNAIRE).  Abbreviated terms may
 #'   also be used: (DEMO, DIET, EXAM, LAB, Q).
 #' @param nh_table The name of an NHANES table.
-#' @param local logical flag. If \code{TRUE}, and a local or
-#'   alternative source was specificed using the environment variable
-#'   \code{NHANES_TABLE_BASE}, this will be used in preference to the
-#'   CDC website at \url{https://wwwn.cdc.gov} for named tables.
+#' @param local logical flag. If \code{TRUE}, and local cacheing is enabled, then the
+#'   cached file will be shown instead of the one in the NHANES website. 
 #' @param browse logical flag, indicating whether the specific NHANES
 #'   site should be opened using a browser (which is the default
 #'   behaviour).
@@ -341,8 +339,8 @@ browseNHANES <- function(year = NULL, data_group = NULL, nh_table = NULL,
       handleURL("https://wwwn.cdc.gov/nchs/nhanes/dxa/dxa.aspx")
     } else {
       nh_year <- .get_year_from_nh_table(nh_table)
-      url <- paste0(if (local) nhanesTableURL else nhanesURL,
-                   nh_year, '/', nh_table, '.htm')
+      url <- paste0(nhanesURL, nh_year, '/', nh_table, '.htm')
+      if (local) url <- .wrapURL(url)
       handleURL(url)
     }
   } else if(!is.null(year)) {

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -1,27 +1,7 @@
 # nhanes_constants.R
 
-## The two 'constants' nhanesTableURL and nhanesManifestPrefix are
-## designed to be changed dynamically (currently by setting an
-## environment variable) to allow <table>.htm and <table>.xpt files
-## to be accessed from a location other than the NHANES website (e.g.,
-## from a local copy). To keep the implementing functions see them as
-## regular character variables, we implement them as active bindings
-## (see .onLoad() in zzz.R).
-
-## nhanesTableURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
-## nhanesManifestPrefix <- 'https://wwwn.cdc.gov'
-
-ab_nhanesTableURL <- function(x) {
-    if (!missing(x)) stop("Invalid assignment")
-    paste0(Sys.getenv("NHANES_TABLE_BASE", unset = "https://wwwn.cdc.gov"),
-           "/Nchs/Nhanes/")
-}
-
-ab_nhanesManifestPrefix <- function(x) {
-    if (!missing(x)) stop("Invalid assignment")
-    Sys.getenv("NHANES_TABLE_BASE", unset = "https://wwwn.cdc.gov")
-}
-
+nhanesTableURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
+nhanesManifestPrefix <- 'https://wwwn.cdc.gov'
 
 nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 dataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx'

--- a/R/nhanes_internal_functions.R
+++ b/R/nhanes_internal_functions.R
@@ -60,7 +60,7 @@
     {
       # when "try" is successful, 'tryCatch()' returns the html 
       if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
-      xml2::read_html(.wrapURL(url))
+      xml2::read_html(.wrapURL(url, prefix = ""))
     },
     error=function(cond) {
       # If there is an error, determine if it's a timeout error or URL error 
@@ -94,9 +94,9 @@
 # .wrapURL(url) allows cache-ing downloaded files using
 # BiocFileCache. Supported by nhanesOptions(use.cache = FALSE)
 
-.wrapURL <- function(url) {
-  if (isTRUE(nhanesOptions(use.cache)) && requireNamespace("BiocFileCache"))
-    bfcrpath(BiocFileCache(), url)
+.wrapURL <- function(url, prefix = "file://") {
+  if (isTRUE(nhanesOptions("use.cache")) && requireNamespace("BiocFileCache", quietly = TRUE))
+    paste0(prefix, BiocFileCache::bfcrpath(BiocFileCache::BiocFileCache(), url))
   else
     url
 }

--- a/R/nhanes_internal_functions.R
+++ b/R/nhanes_internal_functions.R
@@ -60,7 +60,7 @@
     {
       # when "try" is successful, 'tryCatch()' returns the html 
       if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
-      xml2::read_html(url)
+      xml2::read_html(.wrapURL(url))
     },
     error=function(cond) {
       # If there is an error, determine if it's a timeout error or URL error 
@@ -91,3 +91,12 @@
 
 
 
+# .wrapURL(url) allows cache-ing downloaded files using
+# BiocFileCache. Supported by nhanesOptions(use.cache = FALSE)
+
+.wrapURL <- function(url) {
+  if (isTRUE(nhanesOptions(use.cache)) && requireNamespace("BiocFileCache"))
+    bfcrpath(BiocFileCache(), url)
+  else
+    url
+}

--- a/R/nhanes_options.R
+++ b/R/nhanes_options.R
@@ -13,9 +13,11 @@
 ##' currently set options are returned as a list.
 ##'
 ##' Options currently used in the package are 'use.db' (logical flag
-##' controlling whether a database should be used if available), and
-##' 'log.access', a logical flag that logs any attempted URL access by
-##' printing the URL).
+##' controlling whether a database should be used if available),
+##' 'use.cache' (logical flag controlling whether the BiocFileCache
+##' (Bioconductor) package should be used, if available, to cache
+##' downloaded files), and 'log.access', a logical flag that logs any
+##' attempted URL access by printing the URL).
 ##' @title Options for the nhanesA package
 ##' @param ... either one or more named arguments giving options to be
 ##'     set (in the form \code{key = value}), or a single unnamed

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -73,12 +73,6 @@ validTables <- function() .dbEnv$validTables
 .onLoad = function(libname, pkgname)
 {
   nhanesOptions(use.db = .init_db())
-  makeActiveBinding(sym = "nhanesManifestPrefix",
-                    fun = ab_nhanesManifestPrefix,
-                    env = environment(ab_nhanesManifestPrefix))
-  makeActiveBinding(sym = "nhanesTableURL",
-                    fun = ab_nhanesTableURL,
-                    env = environment(ab_nhanesTableURL))
   ## declare 'global' variables used in subset() to make codetools happy 
   utils::globalVariables(c("Begin.Year", "Component", "Data.File",
                            "Data.File.Name", "Date.Published", "Doc.File",

--- a/man/browseNHANES.Rd
+++ b/man/browseNHANES.Rd
@@ -21,10 +21,8 @@ also be used: (DEMO, DIET, EXAM, LAB, Q).}
 
 \item{nh_table}{The name of an NHANES table.}
 
-\item{local}{logical flag. If \code{TRUE}, and a local or
-alternative source was specificed using the environment variable
-\code{NHANES_TABLE_BASE}, this will be used in preference to the
-CDC website at \url{https://wwwn.cdc.gov} for named tables.}
+\item{local}{logical flag. If \code{TRUE}, and local cacheing is enabled, then the
+cached file will be shown instead of the one in the NHANES website.}
 
 \item{browse}{logical flag, indicating whether the specific NHANES
 site should be opened using a browser (which is the default

--- a/man/nhanesOptions.Rd
+++ b/man/nhanesOptions.Rd
@@ -29,9 +29,11 @@ using 'nhanesOptions("key")'. When called with no arguments, all
 currently set options are returned as a list.
 
 Options currently used in the package are 'use.db' (logical flag
-controlling whether a database should be used if available), and
-'log.access', a logical flag that logs any attempted URL access by
-printing the URL).
+controlling whether a database should be used if available),
+'use.cache' (logical flag controlling whether the BiocFileCache
+(Bioconductor) package should be used, if available, to cache
+downloaded files), and 'log.access', a logical flag that logs any
+attempted URL access by printing the URL).
 }
 \examples{
  nhanesOptions(foo = "bar")


### PR DESCRIPTION
This allows the option of caching downloaded files using the BiocFileCache package. As this is much more well tested, the patch also removes the earlier 'local mirror' option.
