### PR TITLE
improve manifest parsing by removing useless rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhanesA
-Version: 0.8.9
-Date: 2023-11-06
+Version: 0.8.10
+Date: 2023-11-30
 Title: NHANES Data Retrieval
 Authors@R:
     c(person(given = "Christopher",


### PR DESCRIPTION
Improve manifest parsing by removing duplicate rows, and also remove hard-coded checks for the table manifest.