### PR TITLE
Add timeout-adjustment based on file size for nhanes() and similar functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhanesA
-Version: 0.9.1
-Date: 2024-01-02
+Version: 0.9.2
+Date: 2024-01-03
 Title: NHANES Data Retrieval
 Authors@R:
     c(person(given = "Christopher",

--- a/R/nhanes_tables.R
+++ b/R/nhanes_tables.R
@@ -4,15 +4,9 @@
 #   nhanesTableVars
 #------------------------------------------------------------------------------
 
-.get_content_length <- function(url, verbose = FALSE)
+
+.nhanesContentLength <- function(url)
 {
-    url_base <- "https://wwwn.cdc.gov"
-    if (!startsWith(url, "/Nchs/Nhanes")) {
-        if (verbose) message("SKIPPING ", url)
-        return(NA_real_)
-    }
-    url <- paste0(url_base, url)
-    if (verbose) message(url)
     h <- tolower(curlGetHeaders(url))
     ok <- startsWith(h, "content-length")
     if (any(ok)) {
@@ -22,6 +16,19 @@
     }
     else NA_real_
 }
+
+
+.get_content_length <- function(url, verbose = FALSE)
+{
+    url_base <- "https://wwwn.cdc.gov"
+    if (!startsWith(url, "/Nchs/Nhanes")) {
+        if (verbose) message("SKIPPING ", url)
+        return(NA_real_)
+    }
+    url <- paste0(url_base, url)
+    if (verbose) message(url)
+    .nhanesContentLength(url)
+ }
 
 ##' Downloads and parses NHANES manifests for public data
 ##' (available at

--- a/R/nhanes_tables.R
+++ b/R/nhanes_tables.R
@@ -5,7 +5,7 @@
 #------------------------------------------------------------------------------
 
 
-.nhanesContentLength <- function(url)
+.nhanesFileSize <- function(url)
 {
     h <- tolower(curlGetHeaders(url))
     ok <- startsWith(h, "content-length")
@@ -13,6 +13,16 @@
         ## pick the last one
         id <- rev(which(ok))[[1]]
         as.numeric(strsplit(trimws(h[[id]]), ":")[[1]][[2]])
+    }
+    else NA_real_
+}
+
+estimate_timeout <- function(url, factor = 1, perMB = 10)
+{
+    ## By default, estimate at 10 sec / MB, and multiply by factor
+    if (factor > 0) {
+        fsize <- .nhanesFileSize(url)
+        factor * perMB * (fsize / 1e6)
     }
     else NA_real_
 }
@@ -27,7 +37,7 @@
     }
     url <- paste0(url_base, url)
     if (verbose) message(url)
-    .nhanesContentLength(url)
+    .nhanesFileSize(url)
  }
 
 ##' Downloads and parses NHANES manifests for public data

--- a/man/nhanes.Rd
+++ b/man/nhanes.Rd
@@ -9,7 +9,8 @@ nhanes(
   includelabels = FALSE,
   translated = TRUE,
   cleanse_numeric = FALSE,
-  nchar = 128
+  nchar = 128,
+  adjust_timeout = TRUE
 )
 }
 \arguments{
@@ -26,6 +27,13 @@ codes in numeric variables, such as \sQuote{Refused} and
 
 \item{nchar}{Maximum length of translated string (default =
 128). Ignored if translated=FALSE.}
+
+\item{adjust_timeout}{Typically a logical flag indicating whether
+the default \code{\link{download.file}} timeout option should be
+adjusted by taking into account the size of the file to be
+downloaded, as reported by the server. The value can also be a
+positive numeric value, in which case it is used as a further
+multiplicative factor for the default calculation.}
 }
 \value{
 The table is returned as a data frame.

--- a/man/nhanesDXA.Rd
+++ b/man/nhanesDXA.Rd
@@ -4,7 +4,7 @@
 \alias{nhanesDXA}
 \title{Import Dual Energy X-ray Absorptiometry (DXA) data.}
 \usage{
-nhanesDXA(year, suppl = FALSE, destfile = NULL)
+nhanesDXA(year, suppl = FALSE, destfile = NULL, adjust_timeout = TRUE)
 }
 \arguments{
 \item{year}{The year of the data to import, where 1999<=year<=2006.}
@@ -13,6 +13,13 @@ nhanesDXA(year, suppl = FALSE, destfile = NULL)
 
 \item{destfile}{The name of a destination file. If NULL then the data are imported 
 into the R environment but no file is created.}
+
+\item{adjust_timeout}{Typically a logical flag indicating whether
+the default \code{\link{download.file}} timeout option should be
+adjusted by taking into account the size of the file to be
+downloaded, as reported by the server. The value can also be a
+positive numeric value, in which case it is used as a further
+multiplicative factor for the default calculation.}
 }
 \value{
 By default the table is returned as a data frame. When downloading to file, the return argument

--- a/man/nhanesFromURL.Rd
+++ b/man/nhanesFromURL.Rd
@@ -4,7 +4,13 @@
 \alias{nhanesFromURL}
 \title{Parse NHANES doc URL}
 \usage{
-nhanesFromURL(url, translated = TRUE, cleanse_numeric = TRUE, nchar = 128)
+nhanesFromURL(
+  url,
+  translated = TRUE,
+  cleanse_numeric = TRUE,
+  nchar = 128,
+  adjust_timeout = TRUE
+)
 }
 \arguments{
 \item{url}{URL of XPT file to be downloaded}
@@ -16,6 +22,13 @@ codes in numeric variables, such as \sQuote{Refused} and
 \sQuote{Don't know} will be converted to \code{NA}.}
 
 \item{nchar}{integer, labels are truncated after this}
+
+\item{adjust_timeout}{Typically a logical flag indicating whether
+the default \code{\link{download.file}} timeout option should be
+adjusted by taking into account the size of the file to be
+downloaded, as reported by the server. The value can also be a
+positive numeric value, in which case it is used as a further
+multiplicative factor for the default calculation.}
 }
 \value{
 data frame


### PR DESCRIPTION
This PR implements a new function `.nhanesFileSize(url)` that returns the content-length header as reported by the server, and optionally uses it to adjust `options("timeout")`. This is active by default, so large downloads should be more likely to complete. Exported functions that have changed are `nhanes()`, `nhanesFromURL()` and `nhanesDXA()`, all of which have a new `adjust_timeout = TRUE` argument.

I am not sure if `.nhanesFileSize(url)` should be exported; feedback from @cjendres1 and @rgentlem welcome.
