### PR TITLE
Include DXA tables in nhanesManifest()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhanesA
-Version: 1.0
-Date: 2024-01-09
+Version: 1.0.1
+Date: 2024-02-14
 Title: NHANES Data Retrieval
 Authors@R:
     c(person(given = "Christopher",

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -73,7 +73,7 @@ nhanes <- function(nh_table, includelabels = FALSE,
     if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
     download.file(url, tf, mode = "wb", quiet = TRUE)
     
-    nh_df <- read.xport(tf)
+    nh_df <- read.xport(tf, check.names = FALSE)
 
     if(translated){
       # suppress warning because there will be a warning and the function returns NULL when no columns need to translated.
@@ -140,7 +140,7 @@ nhanesFromURL <- function(url, translated = TRUE, cleanse_numeric = TRUE,
                           nchar = 128, adjust_timeout = TRUE)
 {
   if (length(url) != 1) stop("'url' must have length 1")
-  if (startsWith(tolower(url), "/nchs/nhanes"))
+  if (startsWith(tolower(url), "/nchs/"))
     url <- paste0(nhanesManifestPrefix, url)
   ## ask server for file size and adjust options("timeout") accordingly
   min_timeout <- estimate_timeout(url, factor = adjust_timeout)
@@ -153,7 +153,7 @@ nhanesFromURL <- function(url, translated = TRUE, cleanse_numeric = TRUE,
       tf <- tempfile()
       if (isTRUE(nhanesOptions("log.access"))) message("Downloading: ", url)
       download.file(url, tf, mode = "wb", quiet = TRUE)
-      nh_df <- read.xport(tf)
+      nh_df <- read.xport(tf, check.names = FALSE)
     },
     error = function(cond) {
       stop(paste0("could not find a XPT file at: ", url))
@@ -235,7 +235,7 @@ nhanesDXA <- function(year, suppl=FALSE, destfile=NULL, adjust_timeout = TRUE) {
         ok <- suppressWarnings(tryCatch({download.file(url, tf, mode="wb", quiet=TRUE)},
                                         error=function(cond){message(cond); return(NULL)}))
         if(!is.null(ok)) {
-          return(read.xport(tf))
+          return(read.xport(tf)) # check.names = FALSE ? Will change X_MULT_ to MULT_
         } else { return(NULL) }
       }
     }
@@ -299,7 +299,7 @@ nhanesAttr <- function(nh_table) {
     column_names  <- xport_struct[[1]]$name
     column_labels <- xport_struct[[1]]$label
     names(column_labels) <- column_names
-    nh_df <- read.xport(tf)
+    nh_df <- read.xport(tf, check.names = FALSE)
     
     nhtatt <- attributes(nh_df)
     nhtatt$row.names <- NULL

--- a/R/nhanes_codebook.R
+++ b/R/nhanes_codebook.R
@@ -83,7 +83,7 @@ nhanesCodebook <- function(nh_table, colname=NULL, dxa=FALSE) {
 ##' @export
 nhanesCodebookFromURL <- function(url) {
   if (length(url) != 1) stop("'url' must have length 1")
-  if (startsWith(tolower(url), "/nchs/nhanes"))
+  if (startsWith(tolower(url), "/nchs/"))
     url <- paste0(nhanesManifestPrefix, url)
   hurl <- .checkHtml(url)
   if (is.null(hurl) ||  is.na(hurl)) {

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -27,6 +27,7 @@ nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 dataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx'
 ladDataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx?Component=LimitedAccess'
 dxaURL  <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/"
+dxaTablesURL  <- "https://wwwn.cdc.gov/Nchs/Nhanes/Dxa/Dxa.aspx"
 
 demoURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Demographics"
 dietURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Dietary"

--- a/R/nhanes_tables.R
+++ b/R/nhanes_tables.R
@@ -87,7 +87,7 @@ estimate_timeout <- function(url, factor = 1, perMB = 10)
 ##' 
 ##' @export
 nhanesManifest <- function(which = c("public", "limitedaccess", "variables"),
-                           sizes = FALSE, dxa = TRUE,
+                           sizes = FALSE, dxa = FALSE,
                            verbose = getOption("verbose"),
                            use_cache = TRUE, max_age = 24 * 60 * 60)
 {

--- a/man/nhanesManifest.Rd
+++ b/man/nhanesManifest.Rd
@@ -7,6 +7,7 @@
 nhanesManifest(
   which = c("public", "limitedaccess", "variables"),
   sizes = FALSE,
+  dxa = TRUE,
   verbose = getOption("verbose"),
   use_cache = TRUE,
   max_age = 24 * 60 * 60
@@ -19,6 +20,10 @@ available variables.}
 
 \item{sizes}{Logical, whether to compute data file sizes (as
 reported by the server) and include them in the result.}
+
+\item{dxa}{Logical, whether to include information on DXA tables.
+These tables contain imputed imputed Dual Energy X-ray Absorptiometry
+measurements, and are listed separately, not in the main listing.}
 
 \item{verbose}{Logical flag indicating whether information on
 progress should be reported.}

--- a/man/nhanesManifest.Rd
+++ b/man/nhanesManifest.Rd
@@ -7,7 +7,7 @@
 nhanesManifest(
   which = c("public", "limitedaccess", "variables"),
   sizes = FALSE,
-  dxa = TRUE,
+  dxa = FALSE,
   verbose = getOption("verbose"),
   use_cache = TRUE,
   max_age = 24 * 60 * 60


### PR DESCRIPTION
As usual, things are not straightforward. Some minor edits that were needed:

- DXA URLs start with `/nchs/data/` rather than `/Nchs/Nhanes/`, so the checks had to be adjusted.

- The DXA tables have a column named `_MULT_`, which `read.xport()` by default converts to `X_MULT_` via `as.data.frame()`, which would mess with the translation because the codebook name would not match. I adjusted this in all cases, _except_ `nhanesDXA()` for the sake of back-compatibility. @cjendres1 please let me know if you would want to change that as well.

- This uncovered a minor bug in `parseRedirect()` to handle the VID URLs, which I have fixed.

The main problem of course is that while the DXX_D documentation is in the standard HTML format, the others (DXX, DXX_B, DXX_C) are PDF files. Most variables in the datasets are common, with a few exceptions (which I haven't explored in detail), so pretending that the DXX_D documentation is valid for all four should be mostly OK.

```
> tabs = c("/nchs/data/nhanes/dxa/dxx.xpt", "/nchs/data/nhanes/dxa/dxx_b.xpt", "/nchs/data/nhanes/dxa/dxx_c.xpt", "/nchs/data/nhanes/dxa/dxx_d.xpt")
> dlist = lapply(tabs, nhanesFromURL, translated = FALSE)
> lapply(dlist, names) |> sapply(length)
[1] 106 106 106 107
> lapply(dlist, names) |> Reduce(f = intersect) |> length()
[1] 105
```

I am not including the DXA tables in the manifest by default for now. We may revisit that once we figure out the implications on downstream workflows.
