### PR TITLE
bugfix in alternative translation code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhanesA
-Version: 1.0.1
-Date: 2024-02-14
+Version: 1.0.2
+Date: 2024-02-26
 Title: NHANES Data Retrieval
 Authors@R:
     c(person(given = "Christopher",

--- a/R/nhanes_translate.R
+++ b/R/nhanes_translate.R
@@ -421,11 +421,24 @@ code2categorical <- function(x, cb) {
     map[as.character(x)]
 }
 
+## some variables are already character strings, but they may also
+## have 'special' codes that need to be translated. code2categorical
+## will not handle them because unrecognized codes become NA
+char2categorical <- function(x, cb) {
+    if (!is.character(x)) stop("Expected character, found ", typeof(x))
+    map <- with(cb, structure(Value.Description, names = as.character(Code.or.Value)))
+    i <- which(x %in% names(map)) # should be relatively few
+    x[i] <- map[x[i]]
+    x
+}
+
 translateVariable <- function(x, cb, cleanse_numeric = TRUE) {
     colnames(cb) <- make.names(colnames(cb)) # 'fix' names if needed
     ## decide if 'numeric'
     if ("Range of Values" %in% cb$Value.Description)
         code2numeric(x, cb, cleanse = cleanse_numeric)
+    else if ("Value was recorded" %in% cb$Value.Description)
+        char2categorical(x, cb)
     else
         code2categorical(x, cb)
 }


### PR DESCRIPTION
This PR fixes a bug in the (simpler) translation code used in nhanesFromURL(). Example:

```
library(nhanesA)
nhanesOptions(log.access = TRUE, use.db = FALSE)
table  <-  "DSQ2_B"
v <- "DSDSUPID"
rawdf <- nhanes(table, translated = FALSE)
codebook <- nhanesCodebook(table)
ans <- nhanesA:::translateVariable(rawdf[[v]], codebook[[v]][[v]], cleanse_numeric = FALSE)
str(ans) # NA before bugfix
# chr [1:9073] "1000126900" "1000448400" "1000012301" "1000072300" "1888086401" ...
str(rawdf[[v]])
# chr [1:9073] "1000126900" "1000448400" "1000012301" "1000072300" "1888086401" ...
str(codebook[[v]][[v]]) # This happens for character variables
# tibble [4 × 5] (S3: tbl_df/tbl/data.frame)
# $ Code or Value    : chr [1:4] "Supplement ID number" "7777777777" "9999999999" "< blank >"
# $ Value Description: chr [1:4] "Value was recorded" "Refused" "Don't know" "Missing"
# $ Count            : int [1:4] 9042 9 22 0
# $ Cumulative       : int [1:4] 9042 9051 9073 9073
# $ Skip to Item     : logi [1:4] NA NA NA NA

transdf <- nhanes(table) # check whether nhanes() results match
str(transdf[[v]])
# Factor w/ 2301 levels "1000011801","1000012200",..: 323 1542 4 201 1953 802 1888 112 2045 2058 ...
table(as.character(transdf[[v]]) == ans)
# TRUE 
# 9073 
```
