### PR TITLE
Minimal updates to fix nhanes(), nhanesSearch(), nhanesCodebook() following CDC reorganization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhanesA
 Version: 1.1.7
-Date: 2024-11-13
+Date: 2024-11-23
 Title: NHANES Data Retrieval
 Authors@R:
     c(person(given = "Christopher",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhanesA
-Version: 1.2
-Date: 2024-12-02
+Version: 1.2.0
+Date: 2024-12-18
 Title: NHANES Data Retrieval
 Authors@R:
     c(person(given = "Christopher",

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -61,7 +61,7 @@ nhanes <- function(nh_table, includelabels = FALSE,
     if(startsWith(nh_table, "Y_")) {
       url <- paste0('https://wwwn.cdc.gov/Nchs/', nh_year, '/', nh_table, '.XPT')
     } else {
-      url <- paste0(nhanesTableURL, nh_year, '/', nh_table, '.XPT')
+      url <- paste0(nhanesTableURL, nh_year, '/DataFiles/', nh_table, '.XPT')
     }
     ## ask server for file size and adjust options("timeout") accordingly
     min_timeout <- estimate_timeout(url, factor = adjust_timeout)
@@ -290,7 +290,7 @@ nhanesAttr <- function(nh_table) {
     if(startsWith(nh_table, "Y_")) {
       url <- paste0('https://wwwn.cdc.gov/Nchs/', nh_year, '/', nh_table, '.XPT')
     } else {
-      url <- paste0(nhanesTableURL, nh_year, '/', nh_table, '.XPT')
+      url <- paste0(nhanesTableURL, nh_year, '/DataFiles/', nh_table, '.XPT')
     }
     
     tf <- tempfile()
@@ -391,13 +391,13 @@ browseNHANES <- function(year = NULL, data_group = NULL, nh_table = NULL,
     } else {
       nh_year <- .get_year_from_nh_table(nh_table)
       url <- paste0(if (local) nhanesTableURL else nhanesURL,
-                   nh_year, '/', nh_table, '.htm')
+                   nh_year, '/DataFiles/', nh_table, '.htm')
       handleURL(url)
     }
   } else if(!is.null(year)) {
     if(!is.null(data_group)) {
       nh_year <- .get_nh_survey_years(year)
-      url <- paste0(nhanesURL, 'Search/DataPage.aspx?Component=', 
+      url <- paste0(nhanesSearchURL, 'Search/DataPage.aspx?Component=', 
                     nhanes_group[data_group],
                     '&CycleBeginYear=', unlist(str_split(nh_year, '-'))[[1]])
       handleURL(url)
@@ -405,7 +405,7 @@ browseNHANES <- function(year = NULL, data_group = NULL, nh_table = NULL,
       nh_year <- .get_nh_survey_years(year)
 #      nh_year <- str_c(str_sub(unlist(str_extract_all(nh_year,"[[:digit:]]{4}")),3,4),collapse='_')
       nh_year <- unlist(str_extract_all(nh_year, "[[:digit:]]{4}"))[1]
-      url <- paste0(nhanesURL, 'continuousnhanes/default.aspx?BeginYear=', nh_year)
+      url <- paste0(nhanesSearchURL, 'continuousnhanes/default.aspx?BeginYear=', nh_year)
       handleURL(url)
     }
   } else {

--- a/R/nhanesDB.R
+++ b/R/nhanesDB.R
@@ -303,8 +303,9 @@
                                      tolower(substr(DataGroup, 2, 20))),
                   Begin.Year = BeginYear,
                   EndYear = EndYear)
-  if (!isTRUE(includerdc))
-    query <- metadata_questionnaire_descriptions |>
+  if (!isTRUE(includerdc)) 
+    query <- 
+      query |>
       dplyr::filter(UseConstraints == "None")
   
   # Apply search terms

--- a/R/nhanes_codebook.R
+++ b/R/nhanes_codebook.R
@@ -48,7 +48,7 @@ nhanesCodebook <- function(nh_table, colname=NULL, dxa=FALSE) {
     if(nh_year == "Nnyfs"){
       url <- paste0("https://wwwn.cdc.gov/Nchs/", nh_year, '/', nh_table, '.htm')
     } else {
-      url <- paste0(nhanesTableURL, nh_year, '/', nh_table, '.htm')
+      url <- paste0(nhanesTableURL, nh_year, '/DataFiles/', nh_table, '.htm')
     }
   }
   hurl <- .checkHtml(url)

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -11,10 +11,13 @@
 ## nhanesTableURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 ## nhanesManifestPrefix <- 'https://wwwn.cdc.gov'
 
+### sample of new path after changes in November 2024
+## https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/2013/DataFiles/DEMO_H.htm
+
 ab_nhanesTableURL <- function(x) {
     if (!missing(x)) stop("Invalid assignment")
     paste0(Sys.getenv("NHANES_TABLE_BASE", unset = "https://wwwn.cdc.gov"),
-           "/Nchs/Nhanes/")
+           "/Nchs/Data/Nhanes/Public/")
 }
 
 ab_nhanesManifestPrefix <- function(x) {
@@ -23,7 +26,8 @@ ab_nhanesManifestPrefix <- function(x) {
 }
 
 
-nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
+nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/'
+nhanesSearchURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 dataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx'
 ladDataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx?Component=LimitedAccess'
 dxaURL  <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/"
@@ -72,12 +76,13 @@ nh_years <-
 
 # Continuous NHANES table names have a letter suffix that indicates the collection interval
 data_idx <-
-  c(A = "1999-2000", a = "1999-2000", B = "2001-2002", b = "2001-2002", 
-    C = "2003-2004", c = "2003-2004", D = "2005-2006", E = "2007-2008", 
-    F = "2009-2010", G = "2011-2012", H = "2013-2014", I = "2015-2016", 
-    J = "2017-2018", K = "2019-2020", L = "2021-2022", M = "2023-2024")
+  c(A = "1999", a = "1999", B = "2001", b = "2001", 
+    C = "2003", c = "2003", D = "2005", E = "2007", 
+    F = "2009", G = "2011", H = "2013", I = "2015", 
+    J = "2017", K = "2019", L = "2021", M = "2023")
 
-anomalytables2005 <- c('CHLMD_DR', 'SSUECD_R', 'HSV_DR')
+anomalytables2003 <- c('SSUECD_R')
+anomalytables2005 <- c('CHLMD_DR', 'HSV_DR')
 nchar_max <- 1024
 nchar_default <- 128
 

--- a/R/nhanes_internal_functions.R
+++ b/R/nhanes_internal_functions.R
@@ -11,11 +11,12 @@
 # If there is no suffix, then we are likely dealing with data from 1999-2000.
 
 .get_year_from_nh_table <- function(nh_table) {
-  if(nh_table %in% anomalytables2005) { return('2005-2006') }
-  if(startsWith(nh_table, "P_")) { return('2017-2018') } # Pre-pandemic
+  if(nh_table %in% anomalytables2005) { return('2005') }
+  else if(nh_table %in% anomalytables2003) { return('2003') }
+  if(startsWith(nh_table, "P_")) { return('2017') } # Pre-pandemic
   if(startsWith(nh_table, "Y_")) { return('Nnyfs') } # Youth survey
   ## exceptions: PFC_POOL and SSNH4THY are cycle 2 but don't have _B suffix
-  if(nh_table %in% c("PFC_POOL", "SSNH4THY")) { return('2001-2002') }
+  if(nh_table %in% c("PFC_POOL", "SSNH4THY")) { return('2001') }
   nhloc <- data.frame(stringr::str_locate_all(nh_table, '_'))
   nn <- nrow(nhloc)
   if(nn!=0){ #Underscores were found
@@ -29,9 +30,9 @@
       }
       return(data_idx[idx])
     } else { ## Underscore not 2nd to last. Assume table is from the first set.
-      return("1999-2000")}
+      return("1999")}
   } else { #If there are no underscores then table must be from first survey
-    return("1999-2000")
+    return("1999")
   }
   ## FIXME check: may be simpler to just check endsWith("_A"), endsWith("_B"), etc
 }

--- a/R/nhanes_translate.R
+++ b/R/nhanes_translate.R
@@ -128,7 +128,7 @@ nhanesTranslate <- function(nh_table, colnames=NULL, data = NULL, nchar = 128,
       if(nh_year == "Nnyfs"){
         paste0("https://wwwn.cdc.gov/Nchs/", nh_year, '/', nh_table, '.htm')
       } else {
-        paste0(nhanesTableURL, nh_year, '/', nh_table, '.htm')
+        paste0(nhanesTableURL, nh_year, '/DataFiles/', nh_table, '.htm')
       }
   }
   hurl <- .checkHtml(code_translation_url)


### PR DESCRIPTION
This patch just updates the various hard-coded URL constants. 

A better longer term solution would be to get file URLs from the main table manifest.
