### PR TITLE
Update DXA url

### DIFF
--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -1,5 +1,5 @@
 #nhanesA - retrieve data from the CDC NHANES repository
-# Christopher J. Endres 09/14/2023
+# 
 # FUNCTIONS:
 #   nhanes
 #   nhanesFromURL
@@ -224,10 +224,10 @@ nhanesDXA <- function(year, suppl=FALSE, destfile=NULL, adjust_timeout = TRUE) {
 
   dxa_fname <- function(year, suppl) {
     fname <- 
-      if(year == 1999 || year == 2000) { 'dxx'}
-      else if(year == 2001 || year == 2002) { 'dxx_b'}
-      else if(year == 2003 || year == 2004) { 'dxx_c'}
-      else if(year == 2005 || year == 2006) { 'DXX_D'}
+      if(year == 1999 || year == 2000) { '1999/datafiles/dxx'}
+      else if(year == 2001 || year == 2002) { '2001/datafiles/dxx_b'}
+      else if(year == 2003 || year == 2004) { '2003/datafiles/dxx_c'}
+      else if(year == 2005 || year == 2006) { '2005/datafiles/DXX_D'}
     if(isTRUE(suppl)) {
       fname <- paste0(fname, 
                       if(year == 2005 || year == 2006) '_S' else '_s')

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -40,7 +40,7 @@ ab_nhanesManifestPrefix <- function(x) {
 nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 dataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx'
 ladDataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx?Component=LimitedAccess'
-dxaURL  <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/"
+dxaURL  <- 'https://wwwn.cdc.gov/nchs/data/nhanes/public/'
 dxaTablesURL  <- "https://wwwn.cdc.gov/Nchs/Nhanes/Dxa/Dxa.aspx"
 
 demoURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Demographics"


### PR DESCRIPTION
The dxa url's are now different for each year. Before it was a single url location that had all the files.
Tested each of the files (there are only 8 total) and was able to retrieve them.